### PR TITLE
Update translitbg.js

### DIFF
--- a/src/translitbg.js
+++ b/src/translitbg.js
@@ -114,7 +114,7 @@
 
         if (mode.tokens.ia[curToken]) {
           var nextNext = chars[i + 2];
-          if (!nextNext || /^[-\s]$/.test(nextNext)) {
+          if (!nextNext || !/^\w+$/.test(nextNext)) {
             result.push(mode.tokens.ia[curToken]);
             i++;
             continue;


### PR DESCRIPTION
The reason why !/^\w+$/.test(s) is better than /^[-\s]$/.test(s) is because if you want to check if the string s contains any non-word characters, such as punctuation, symbols, or spaces, then !/^\w+$/.test(s) is better, because it will return true for any string that has at least one non-word character, regardless of its length or position. For example "гр. София, бул. Трон 12", will now be transliterated to "gr. Sofia, bul. Tron 12", instead of "gr. Sofiya, bul. Tron 12"